### PR TITLE
[#13] Moving from `always` trailing commas to `always-multiline`

### DIFF
--- a/lib/rules/base.js
+++ b/lib/rules/base.js
@@ -35,10 +35,11 @@ module.exports = {
         'properties': 'always'
       }
     ],
-    // enforces the usage of trailing commas
+    // enforces the usage of trailing commas for multiline statements
+    // enforces no trailing commas for singleline statements
     'comma-dangle': [
       'error',
-      'always'
+      'always-multiline'
     ],
     // enforces a style where it enforces no space before comma but requires a space after comma
     'comma-spacing': [


### PR DESCRIPTION
- #13 

## What happened

Change comma-dangle from always to always-multiline in order to enforce no trailing comma for single-line statements.
 
## Insight

This change fixes a conflict introduced in 2.0.0 [#12] as a single-line statement would have a space before the closing `]` for arrays: `, ]`.
 
## Proof Of Work

Comment added to clarify both implications of this single rule:

![image](https://user-images.githubusercontent.com/77609814/140299399-3c29ea48-3123-452a-b412-ec1dd6f7fc19.png)
