### PR TITLE
[#21] Add the project's maintainers info

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# Team
+# @carryall is the Team Lead and the others are team members
+* @carryall @nimblehq/web-chapter
+
+# Engineering Leads
+CODEOWNERS @nimblehq/engineering-leads


### PR DESCRIPTION
Close https://github.com/nimblehq/eslint-config-nimble/issues/21

## What happened 👀

Add `CODEOWNERS` in the subdirectory `.github`

## Insight 📝

All project template repositories now have official leads so it is crucial to have it documented. In addition, this will ensure that all concerned developers are notified when new pull requested are created ✌️ 

## Proof Of Work 📹

![image](https://user-images.githubusercontent.com/696529/160563878-bd1b4ed7-5972-440c-ba28-82352a3780a8.png)
