### PR TITLE
[#36] Update the publishing information

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,32 @@
+name: Publish packages to npmjs
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  publish:
+    name: Publish packages
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup node and restore cached dependencies
+        uses: actions/setup-node@v3
+        with:
+          node-version: "16.x"
+          cache: "npm"
+          registry-url: "https://registry.npmjs.org"
+          scope: "@nimblehq"
+
+      - name: Install dependencies
+        run: npm ci && lerna bootstrap --ci
+
+      - name: Publish packages to npmjs
+        run: npx lerna publish from-package --yes --no-verify-access
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 The configurations are separated into dedicated packages:
 
 - [eslint-config-nimble](/packages/eslint-config-nimble): ESLint base rules
+- [eslint-config-nimble-react](/packages/eslint-config-nimble-react): ESLint rules for React
 
 __Usage information is in the packages' documentation.__
 
@@ -28,13 +29,11 @@ __Usage information is in the packages' documentation.__
 
 ### Publish packages
 
-Use [`lerna publish`](https://github.com/lerna/lerna/tree/main/commands/publish#readme) command to publish packages.
+- Packages will be published to npmjs automatically after publishing a new release.
 
-```bash
-  lerna publish
-```
+- Need to set the version in `/packages/**/package.json` before creating the release.
 
-_The current branch that you run the publish command should be pushed on Github._
+- More details in [publish workflow](/.github/workflows/publish.yml). This workflow uses [`lerna publish`](https://github.com/lerna/lerna/tree/main/commands/publish#readme) command to publish packages.
 
 ### Run commands
 


### PR DESCRIPTION
Resolves https://github.com/nimblehq/eslint-config-nimble/issues/36

## What happened 👀

- Update README to have publishing information
- Add missing React package in README
- Add `publish` workflow to publish packages automatically

## Insight 📝

- Follow https://github.com/nimblehq/react-templates/pull/114
- Just change to use `NODE_AUTH_TOKEN` env as `actions/setup-node@v3` [support it directly](https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages#publishing-packages-to-the-npm-registry).
- @carryall I need your help on setting `secrets.NPM_TOKEN` to this repository 🙏 

## Proof Of Work 📹

Tested on [stylelint-config-nimble](https://github.com/nimblehq/stylelint-config-nimble/pull/9/commits/da6284d39d40eda16627876be4fcd537b65031ed)
