### PR TITLE
chore: Add node 14.x back to the supporting list

### DIFF
--- a/packages/eslint-config-nimble-core/package.json
+++ b/packages/eslint-config-nimble-core/package.json
@@ -30,7 +30,7 @@
     "lib": "lib"
   },
   "engines": {
-    "node": "^16 || ^17 || ^18"
+    "node": "^14.18.2 || ^16 || ^17 || ^18"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## What happened 👀

Add node 14.x back to the supporting list

## Insight 📝

Some projects are still using Node.JS with the old version 14.x. We need to add v14.x as verified engines.

## Proof Of Work 📹
 On the `Files changed`
