### PR TITLE
[#56] Separate typescript to dedicated package

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@
 The configurations are separated into dedicated packages:
 
 - [eslint-config-nimble-core](/packages/eslint-config-nimble-core): ESLint core base rules
-- [eslint-config-nimble-testing](/packages/eslint-config-nimble-testing): ESLint testing base rules
 - [eslint-config-nimble-react](/packages/eslint-config-nimble-react): ESLint rules for React
+- [eslint-config-nimble-testing](/packages/eslint-config-nimble-testing): ESLint rules for testing
+- [eslint-config-nimble-typescript](/packages/eslint-config-nimble-typescript): ESLint rules for typescript
 
 __Usage information is in the packages' documentation.__
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The configurations are separated into dedicated packages:
 - [eslint-config-nimble-core](/packages/eslint-config-nimble-core): ESLint core base rules
 - [eslint-config-nimble-react](/packages/eslint-config-nimble-react): ESLint rules for React
 - [eslint-config-nimble-testing](/packages/eslint-config-nimble-testing): ESLint rules for testing
-- [eslint-config-nimble-typescript](/packages/eslint-config-nimble-typescript): ESLint rules for typescript
+- [eslint-config-nimble-typescript](/packages/eslint-config-nimble-typescript): ESLint rules for Typescript
 
 __Usage information is in the packages' documentation.__
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10914,8 +10914,8 @@
       "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
-        "@nimblehq/eslint-config-nimble-core": "^2.8.0",
-        "@nimblehq/eslint-config-nimble-typescript": "^1.0.0",
+        "@nimblehq/eslint-config-nimble-core": "2.8.0",
+        "@nimblehq/eslint-config-nimble-typescript": "1.0.0",
         "eslint": "^8.51.0",
         "eslint-config-prettier": "^9.0.0",
         "eslint-plugin-jsx-a11y": "^6.7.1",
@@ -10933,8 +10933,8 @@
       "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
-        "@nimblehq/eslint-config-nimble-core": "^2.8.0",
-        "@nimblehq/eslint-config-nimble-typescript": "^1.0.0",
+        "@nimblehq/eslint-config-nimble-core": "2.8.0",
+        "@nimblehq/eslint-config-nimble-typescript": "1.0.0",
         "eslint": "^8.51.0",
         "eslint-config-prettier": "^9.0.0",
         "eslint-plugin-import": "^2.28.1",
@@ -10950,7 +10950,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@nimblehq/eslint-config-nimble-core": "^2.8.0",
+        "@nimblehq/eslint-config-nimble-core": "2.8.0",
         "eslint-import-resolver-typescript": "^3.6.1"
       },
       "devDependencies": {
@@ -12059,8 +12059,8 @@
     "@nimblehq/eslint-config-nimble-react": {
       "version": "file:packages/eslint-config-nimble-react",
       "requires": {
-        "@nimblehq/eslint-config-nimble-core": "^2.8.0",
-        "@nimblehq/eslint-config-nimble-typescript": "^1.0.0",
+        "@nimblehq/eslint-config-nimble-core": "2.8.0",
+        "@nimblehq/eslint-config-nimble-typescript": "1.0.0",
         "eslint": "^8.51.0",
         "eslint-config-prettier": "^9.0.0",
         "eslint-plugin-jsx-a11y": "^6.7.1",
@@ -12073,8 +12073,8 @@
     "@nimblehq/eslint-config-nimble-testing": {
       "version": "file:packages/eslint-config-nimble-testing",
       "requires": {
-        "@nimblehq/eslint-config-nimble-core": "^2.8.0",
-        "@nimblehq/eslint-config-nimble-typescript": "^1.0.0",
+        "@nimblehq/eslint-config-nimble-core": "2.8.0",
+        "@nimblehq/eslint-config-nimble-typescript": "1.0.0",
         "eslint": "^8.51.0",
         "eslint-config-prettier": "^9.0.0",
         "eslint-plugin-import": "^2.28.1",
@@ -12085,7 +12085,7 @@
     "@nimblehq/eslint-config-nimble-typescript": {
       "version": "file:packages/eslint-config-nimble-typescript",
       "requires": {
-        "@nimblehq/eslint-config-nimble-core": "^2.8.0",
+        "@nimblehq/eslint-config-nimble-core": "2.8.0",
         "@typescript-eslint/eslint-plugin": "^6.18.1",
         "@typescript-eslint/parser": "^6.18.1",
         "eslint": "^8.56.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10897,7 +10897,7 @@
     },
     "packages/eslint-config-nimble-core": {
       "name": "@nimblehq/eslint-config-nimble-core",
-      "version": "2.7.0",
+      "version": "2.8.0",
       "license": "MIT",
       "dependencies": {
         "eslint": "^8.51.0",
@@ -10948,7 +10948,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@nimblehq/eslint-config-nimble-core": "^2.7.0",
+        "@nimblehq/eslint-config-nimble-core": "^2.8.0",
         "eslint-import-resolver-typescript": "^3.6.1"
       },
       "devDependencies": {
@@ -12081,7 +12081,7 @@
     "@nimblehq/eslint-config-nimble-typescript": {
       "version": "file:packages/eslint-config-nimble-typescript",
       "requires": {
-        "@nimblehq/eslint-config-nimble-core": "^2.7.0",
+        "@nimblehq/eslint-config-nimble-core": "^2.8.0",
         "@typescript-eslint/eslint-plugin": "^6.18.1",
         "@typescript-eslint/parser": "^6.18.1",
         "eslint": "^8.56.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10914,7 +10914,8 @@
       "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
-        "@nimblehq/eslint-config-nimble-core": "^2.7.0",
+        "@nimblehq/eslint-config-nimble-core": "^2.8.0",
+        "@nimblehq/eslint-config-nimble-typescript": "^1.0.0",
         "eslint": "^8.51.0",
         "eslint-config-prettier": "^9.0.0",
         "eslint-plugin-jsx-a11y": "^6.7.1",
@@ -10932,7 +10933,8 @@
       "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
-        "@nimblehq/eslint-config-nimble-core": "^2.7.0",
+        "@nimblehq/eslint-config-nimble-core": "^2.8.0",
+        "@nimblehq/eslint-config-nimble-typescript": "^1.0.0",
         "eslint": "^8.51.0",
         "eslint-config-prettier": "^9.0.0",
         "eslint-plugin-import": "^2.28.1",
@@ -12057,7 +12059,8 @@
     "@nimblehq/eslint-config-nimble-react": {
       "version": "file:packages/eslint-config-nimble-react",
       "requires": {
-        "@nimblehq/eslint-config-nimble-core": "^2.7.0",
+        "@nimblehq/eslint-config-nimble-core": "^2.8.0",
+        "@nimblehq/eslint-config-nimble-typescript": "^1.0.0",
         "eslint": "^8.51.0",
         "eslint-config-prettier": "^9.0.0",
         "eslint-plugin-jsx-a11y": "^6.7.1",
@@ -12070,7 +12073,8 @@
     "@nimblehq/eslint-config-nimble-testing": {
       "version": "file:packages/eslint-config-nimble-testing",
       "requires": {
-        "@nimblehq/eslint-config-nimble-core": "^2.7.0",
+        "@nimblehq/eslint-config-nimble-core": "^2.8.0",
+        "@nimblehq/eslint-config-nimble-typescript": "^1.0.0",
         "eslint": "^8.51.0",
         "eslint-config-prettier": "^9.0.0",
         "eslint-plugin-import": "^2.28.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -214,9 +214,9 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.2.tgz",
-      "integrity": "sha512-+wvgpDsrB1YqAMdEUCcnTlpfVBH7Vqn6A/NT3D8WVXFIaKMlErPIZT3oCIAVCOtarRpMtelZLqJeU3t7WY6X6g==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+      "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
@@ -236,9 +236,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "8.51.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.51.0.tgz",
-      "integrity": "sha512-HxjQ8Qn+4SI3/AFv6sOrDB+g6PpUTDwSJiQqOrnneEk8L71161srI9gjzzZvYVbzHiVg/BvcH95+cK/zfIt4pg==",
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.56.0.tgz",
+      "integrity": "sha512-gMsVel9D7f2HLkBma9VbtzZRehRogVRfbr++f06nL2vnCGCNlzOD+/MUov/F4p8myyAHspEhVobgjpX64q5m6A==",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
@@ -250,12 +250,12 @@
       "dev": true
     },
     "node_modules/@humanwhocodes/config-array": {
-      "version": "0.11.12",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.12.tgz",
-      "integrity": "sha512-NlGesA1usRNn6ctHCZ21M4/dKPgW9Nn1FypRdIKKgZOKzkVV4T1FlK5mBiLhHBCDmEbdQG0idrcXlbZfksJ+RA==",
+      "version": "0.11.14",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
+      "integrity": "sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==",
       "dependencies": {
-        "@humanwhocodes/object-schema": "^2.0.0",
-        "debug": "^4.1.1",
+        "@humanwhocodes/object-schema": "^2.0.2",
+        "debug": "^4.3.1",
         "minimatch": "^3.0.5"
       },
       "engines": {
@@ -275,9 +275,9 @@
       }
     },
     "node_modules/@humanwhocodes/object-schema": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.0.tgz",
-      "integrity": "sha512-9S9QrXY2K0L4AGDcSgTi9vgiCcG8VcBv4Mp7/1hDPYoswIy6Z6KO5blYto82BT8M0MZNRWmCFLpCs3HlpYGGdw=="
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.2.tgz",
+      "integrity": "sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw=="
     },
     "node_modules/@hutson/parse-repository-url": {
       "version": "3.0.2",
@@ -1381,6 +1381,10 @@
       "resolved": "packages/eslint-config-nimble-testing",
       "link": true
     },
+    "node_modules/@nimblehq/eslint-config-nimble-typescript": {
+      "resolved": "packages/eslint-config-nimble-typescript",
+      "link": true
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -2139,15 +2143,16 @@
       "integrity": "sha512-MMzuxN3GdFwskAnb6fz0orFvhfqi752yjaXylr0Rp4oDg5H0Zn1IuyRhDVvYOwAXoJirx2xuS16I3WjxnAIHiQ=="
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.8.0.tgz",
-      "integrity": "sha512-GosF4238Tkes2SHPQ1i8f6rMtG6zlKwMEB0abqSJ3Npvos+doIlc/ATG+vX1G9coDF3Ex78zM3heXHLyWEwLUw==",
+      "version": "6.18.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.18.1.tgz",
+      "integrity": "sha512-nISDRYnnIpk7VCFrGcu1rnZfM1Dh9LRHnfgdkjcbi/l7g16VYRri3TjXi9Ir4lOZSw5N/gnV/3H7jIPQ8Q4daA==",
+      "devOptional": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.5.1",
-        "@typescript-eslint/scope-manager": "6.8.0",
-        "@typescript-eslint/type-utils": "6.8.0",
-        "@typescript-eslint/utils": "6.8.0",
-        "@typescript-eslint/visitor-keys": "6.8.0",
+        "@typescript-eslint/scope-manager": "6.18.1",
+        "@typescript-eslint/type-utils": "6.18.1",
+        "@typescript-eslint/utils": "6.18.1",
+        "@typescript-eslint/visitor-keys": "6.18.1",
         "debug": "^4.3.4",
         "graphemer": "^1.4.0",
         "ignore": "^5.2.4",
@@ -2173,14 +2178,15 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.8.0.tgz",
-      "integrity": "sha512-5tNs6Bw0j6BdWuP8Fx+VH4G9fEPDxnVI7yH1IAPkQH5RUtvKwRoqdecAPdQXv4rSOADAaz1LFBZvZG7VbXivSg==",
+      "version": "6.18.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.18.1.tgz",
+      "integrity": "sha512-zct/MdJnVaRRNy9e84XnVtRv9Vf91/qqe+hZJtKanjojud4wAVy/7lXxJmMyX6X6J+xc6c//YEWvpeif8cAhWA==",
+      "devOptional": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "6.8.0",
-        "@typescript-eslint/types": "6.8.0",
-        "@typescript-eslint/typescript-estree": "6.8.0",
-        "@typescript-eslint/visitor-keys": "6.8.0",
+        "@typescript-eslint/scope-manager": "6.18.1",
+        "@typescript-eslint/types": "6.18.1",
+        "@typescript-eslint/typescript-estree": "6.18.1",
+        "@typescript-eslint/visitor-keys": "6.18.1",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -2200,12 +2206,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.8.0.tgz",
-      "integrity": "sha512-xe0HNBVwCph7rak+ZHcFD6A+q50SMsFwcmfdjs9Kz4qDh5hWhaPhFjRs/SODEhroBI5Ruyvyz9LfwUJ624O40g==",
+      "version": "6.18.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.18.1.tgz",
+      "integrity": "sha512-BgdBwXPFmZzaZUuw6wKiHKIovms97a7eTImjkXCZE04TGHysG+0hDQPmygyvgtkoB/aOQwSM/nWv3LzrOIQOBw==",
+      "devOptional": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.8.0",
-        "@typescript-eslint/visitor-keys": "6.8.0"
+        "@typescript-eslint/types": "6.18.1",
+        "@typescript-eslint/visitor-keys": "6.18.1"
       },
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -2216,12 +2223,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.8.0.tgz",
-      "integrity": "sha512-RYOJdlkTJIXW7GSldUIHqc/Hkto8E+fZN96dMIFhuTJcQwdRoGN2rEWA8U6oXbLo0qufH7NPElUb+MceHtz54g==",
+      "version": "6.18.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.18.1.tgz",
+      "integrity": "sha512-wyOSKhuzHeU/5pcRDP2G2Ndci+4g653V43gXTpt4nbyoIOAASkGDA9JIAgbQCdCkcr1MvpSYWzxTz0olCn8+/Q==",
+      "devOptional": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "6.8.0",
-        "@typescript-eslint/utils": "6.8.0",
+        "@typescript-eslint/typescript-estree": "6.18.1",
+        "@typescript-eslint/utils": "6.18.1",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.0.1"
       },
@@ -2242,9 +2250,10 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.8.0.tgz",
-      "integrity": "sha512-p5qOxSum7W3k+llc7owEStXlGmSl8FcGvhYt8Vjy7FqEnmkCVlM3P57XQEGj58oqaBWDQXbJDZxwUWMS/EAPNQ==",
+      "version": "6.18.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.18.1.tgz",
+      "integrity": "sha512-4TuMAe+tc5oA7wwfqMtB0Y5OrREPF1GeJBAjqwgZh1lEMH5PJQgWgHGfYufVB51LtjD+peZylmeyxUXPfENLCw==",
+      "devOptional": true,
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
       },
@@ -2254,15 +2263,17 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.8.0.tgz",
-      "integrity": "sha512-ISgV0lQ8XgW+mvv5My/+iTUdRmGspducmQcDw5JxznasXNnZn3SKNrTRuMsEXv+V/O+Lw9AGcQCfVaOPCAk/Zg==",
+      "version": "6.18.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.18.1.tgz",
+      "integrity": "sha512-fv9B94UAhywPRhUeeV/v+3SBDvcPiLxRZJw/xZeeGgRLQZ6rLMG+8krrJUyIf6s1ecWTzlsbp0rlw7n9sjufHA==",
+      "devOptional": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.8.0",
-        "@typescript-eslint/visitor-keys": "6.8.0",
+        "@typescript-eslint/types": "6.18.1",
+        "@typescript-eslint/visitor-keys": "6.18.1",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
+        "minimatch": "9.0.3",
         "semver": "^7.5.4",
         "ts-api-utils": "^1.0.1"
       },
@@ -2279,17 +2290,42 @@
         }
       }
     },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "devOptional": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "devOptional": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/@typescript-eslint/utils": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.8.0.tgz",
-      "integrity": "sha512-dKs1itdE2qFG4jr0dlYLQVppqTE+Itt7GmIf/vX6CSvsW+3ov8PbWauVKyyfNngokhIO9sKZeRGCUo1+N7U98Q==",
+      "version": "6.18.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.18.1.tgz",
+      "integrity": "sha512-zZmTuVZvD1wpoceHvoQpOiewmWu3uP9FuTWo8vqpy2ffsmfCE8mklRPi+vmnIYAIk9t/4kOThri2QCDgor+OpQ==",
+      "devOptional": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
         "@types/json-schema": "^7.0.12",
         "@types/semver": "^7.5.0",
-        "@typescript-eslint/scope-manager": "6.8.0",
-        "@typescript-eslint/types": "6.8.0",
-        "@typescript-eslint/typescript-estree": "6.8.0",
+        "@typescript-eslint/scope-manager": "6.18.1",
+        "@typescript-eslint/types": "6.18.1",
+        "@typescript-eslint/typescript-estree": "6.18.1",
         "semver": "^7.5.4"
       },
       "engines": {
@@ -2304,11 +2340,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.8.0.tgz",
-      "integrity": "sha512-oqAnbA7c+pgOhW2OhGvxm0t1BULX5peQI/rLsNDpGM78EebV3C9IGbX5HNZabuZ6UQrYveCLjKo8Iy/lLlBkkg==",
+      "version": "6.18.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.18.1.tgz",
+      "integrity": "sha512-/kvt0C5lRqGoCfsbmm7/CwMqoSkY3zzHLIjdhHZQW3VFrnz7ATecOHR7nb7V+xn4286MBxfnQfQhAmCI0u+bJA==",
+      "devOptional": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.8.0",
+        "@typescript-eslint/types": "6.18.1",
         "eslint-visitor-keys": "^3.4.1"
       },
       "engines": {
@@ -2318,6 +2355,11 @@
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       }
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
+      "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ=="
     },
     "node_modules/@yarnpkg/lockfile": {
       "version": "1.1.0",
@@ -2379,9 +2421,9 @@
       "dev": true
     },
     "node_modules/acorn": {
-      "version": "8.10.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
-      "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
+      "version": "8.11.3",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
+      "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4064,17 +4106,18 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.51.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.51.0.tgz",
-      "integrity": "sha512-2WuxRZBrlwnXi+/vFSJyjMqrNjtJqiasMzehF0shoLaW7DzS3/9Yvrmq5JiT66+pNjiX4UBnLDiKHcWAr/OInA==",
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.56.0.tgz",
+      "integrity": "sha512-Go19xM6T9puCOWntie1/P997aXxFsOi37JIHRWI514Hc6ZnaHGKY9xFhrU65RT6CcBEzZoGG1e6Nq+DT04ZtZQ==",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
-        "@eslint/eslintrc": "^2.1.2",
-        "@eslint/js": "8.51.0",
-        "@humanwhocodes/config-array": "^0.11.11",
+        "@eslint/eslintrc": "^2.1.4",
+        "@eslint/js": "8.56.0",
+        "@humanwhocodes/config-array": "^0.11.13",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
+        "@ungap/structured-clone": "^1.2.0",
         "ajv": "^6.12.4",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
@@ -5512,9 +5555,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "13.23.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.23.0.tgz",
-      "integrity": "sha512-XAmF0RjlrjY23MA51q3HltdlGxUpXPvg0GioKiD9X6HD28iMjo2dKC8Vqwm7lne4GNr78+RHTfliktR6ZH09wA==",
+      "version": "13.24.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
       "dependencies": {
         "type-fest": "^0.20.2"
       },
@@ -8899,9 +8942,9 @@
       "dev": true
     },
     "node_modules/punycode": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
-      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "engines": {
         "node": ">=6"
       }
@@ -10150,6 +10193,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.3.tgz",
       "integrity": "sha512-wNMeqtMz5NtwpT/UZGY5alT+VoKdSsOOP/kqHFcUW1P/VRhH2wJ48+DN2WwUliNbQ976ETwDL0Ifd2VVvgonvg==",
+      "devOptional": true,
       "engines": {
         "node": ">=16.13.0"
       },
@@ -10856,11 +10900,8 @@
       "version": "2.7.0",
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "^6.8.0",
-        "@typescript-eslint/parser": "^6.8.0",
         "eslint": "^8.51.0",
         "eslint-config-prettier": "^9.0.0",
-        "eslint-import-resolver-typescript": "^3.6.1",
         "eslint-plugin-import": "^2.28.1",
         "eslint-plugin-prettier": "^5.0.1"
       },
@@ -10897,6 +10938,23 @@
         "eslint-plugin-import": "^2.28.1",
         "eslint-plugin-jest": "^27.4.2",
         "eslint-plugin-prettier": "^5.0.1"
+      },
+      "engines": {
+        "node": "^14.18.2 || >=18"
+      }
+    },
+    "packages/eslint-config-nimble-typescript": {
+      "name": "@nimblehq/eslint-config-nimble-typescript",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@nimblehq/eslint-config-nimble-core": "^2.7.0",
+        "eslint-import-resolver-typescript": "^3.6.1"
+      },
+      "devDependencies": {
+        "@typescript-eslint/eslint-plugin": "^6.18.1",
+        "@typescript-eslint/parser": "^6.18.1",
+        "eslint": "^8.56.0"
       },
       "engines": {
         "node": "^14.18.2 || >=18"
@@ -11062,9 +11120,9 @@
       "integrity": "sha512-Y27x+MBLjXa+0JWDhykM3+JE+il3kHKAEqabfEWq3SDhZjLYb6/BHL/JKFnH3fe207JaXkyDo685Oc2Glt6ifA=="
     },
     "@eslint/eslintrc": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.2.tgz",
-      "integrity": "sha512-+wvgpDsrB1YqAMdEUCcnTlpfVBH7Vqn6A/NT3D8WVXFIaKMlErPIZT3oCIAVCOtarRpMtelZLqJeU3t7WY6X6g==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+      "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
       "requires": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
@@ -11078,9 +11136,9 @@
       }
     },
     "@eslint/js": {
-      "version": "8.51.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.51.0.tgz",
-      "integrity": "sha512-HxjQ8Qn+4SI3/AFv6sOrDB+g6PpUTDwSJiQqOrnneEk8L71161srI9gjzzZvYVbzHiVg/BvcH95+cK/zfIt4pg=="
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.56.0.tgz",
+      "integrity": "sha512-gMsVel9D7f2HLkBma9VbtzZRehRogVRfbr++f06nL2vnCGCNlzOD+/MUov/F4p8myyAHspEhVobgjpX64q5m6A=="
     },
     "@gar/promisify": {
       "version": "1.1.3",
@@ -11089,12 +11147,12 @@
       "dev": true
     },
     "@humanwhocodes/config-array": {
-      "version": "0.11.12",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.12.tgz",
-      "integrity": "sha512-NlGesA1usRNn6ctHCZ21M4/dKPgW9Nn1FypRdIKKgZOKzkVV4T1FlK5mBiLhHBCDmEbdQG0idrcXlbZfksJ+RA==",
+      "version": "0.11.14",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
+      "integrity": "sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==",
       "requires": {
-        "@humanwhocodes/object-schema": "^2.0.0",
-        "debug": "^4.1.1",
+        "@humanwhocodes/object-schema": "^2.0.2",
+        "debug": "^4.3.1",
         "minimatch": "^3.0.5"
       }
     },
@@ -11104,9 +11162,9 @@
       "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA=="
     },
     "@humanwhocodes/object-schema": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.0.tgz",
-      "integrity": "sha512-9S9QrXY2K0L4AGDcSgTi9vgiCcG8VcBv4Mp7/1hDPYoswIy6Z6KO5blYto82BT8M0MZNRWmCFLpCs3HlpYGGdw=="
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.2.tgz",
+      "integrity": "sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw=="
     },
     "@hutson/parse-repository-url": {
       "version": "3.0.2",
@@ -11990,11 +12048,8 @@
     "@nimblehq/eslint-config-nimble-core": {
       "version": "file:packages/eslint-config-nimble-core",
       "requires": {
-        "@typescript-eslint/eslint-plugin": "^6.8.0",
-        "@typescript-eslint/parser": "^6.8.0",
         "eslint": "^8.51.0",
         "eslint-config-prettier": "^9.0.0",
-        "eslint-import-resolver-typescript": "^3.6.1",
         "eslint-plugin-import": "^2.28.1",
         "eslint-plugin-prettier": "^5.0.1"
       }
@@ -12021,6 +12076,16 @@
         "eslint-plugin-import": "^2.28.1",
         "eslint-plugin-jest": "^27.4.2",
         "eslint-plugin-prettier": "^5.0.1"
+      }
+    },
+    "@nimblehq/eslint-config-nimble-typescript": {
+      "version": "file:packages/eslint-config-nimble-typescript",
+      "requires": {
+        "@nimblehq/eslint-config-nimble-core": "^2.7.0",
+        "@typescript-eslint/eslint-plugin": "^6.18.1",
+        "@typescript-eslint/parser": "^6.18.1",
+        "eslint": "^8.56.0",
+        "eslint-import-resolver-typescript": "^3.6.1"
       }
     },
     "@nodelib/fs.scandir": {
@@ -12577,15 +12642,16 @@
       "integrity": "sha512-MMzuxN3GdFwskAnb6fz0orFvhfqi752yjaXylr0Rp4oDg5H0Zn1IuyRhDVvYOwAXoJirx2xuS16I3WjxnAIHiQ=="
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.8.0.tgz",
-      "integrity": "sha512-GosF4238Tkes2SHPQ1i8f6rMtG6zlKwMEB0abqSJ3Npvos+doIlc/ATG+vX1G9coDF3Ex78zM3heXHLyWEwLUw==",
+      "version": "6.18.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.18.1.tgz",
+      "integrity": "sha512-nISDRYnnIpk7VCFrGcu1rnZfM1Dh9LRHnfgdkjcbi/l7g16VYRri3TjXi9Ir4lOZSw5N/gnV/3H7jIPQ8Q4daA==",
+      "devOptional": true,
       "requires": {
         "@eslint-community/regexpp": "^4.5.1",
-        "@typescript-eslint/scope-manager": "6.8.0",
-        "@typescript-eslint/type-utils": "6.8.0",
-        "@typescript-eslint/utils": "6.8.0",
-        "@typescript-eslint/visitor-keys": "6.8.0",
+        "@typescript-eslint/scope-manager": "6.18.1",
+        "@typescript-eslint/type-utils": "6.18.1",
+        "@typescript-eslint/utils": "6.18.1",
+        "@typescript-eslint/visitor-keys": "6.18.1",
         "debug": "^4.3.4",
         "graphemer": "^1.4.0",
         "ignore": "^5.2.4",
@@ -12595,78 +12661,111 @@
       }
     },
     "@typescript-eslint/parser": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.8.0.tgz",
-      "integrity": "sha512-5tNs6Bw0j6BdWuP8Fx+VH4G9fEPDxnVI7yH1IAPkQH5RUtvKwRoqdecAPdQXv4rSOADAaz1LFBZvZG7VbXivSg==",
+      "version": "6.18.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.18.1.tgz",
+      "integrity": "sha512-zct/MdJnVaRRNy9e84XnVtRv9Vf91/qqe+hZJtKanjojud4wAVy/7lXxJmMyX6X6J+xc6c//YEWvpeif8cAhWA==",
+      "devOptional": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "6.8.0",
-        "@typescript-eslint/types": "6.8.0",
-        "@typescript-eslint/typescript-estree": "6.8.0",
-        "@typescript-eslint/visitor-keys": "6.8.0",
+        "@typescript-eslint/scope-manager": "6.18.1",
+        "@typescript-eslint/types": "6.18.1",
+        "@typescript-eslint/typescript-estree": "6.18.1",
+        "@typescript-eslint/visitor-keys": "6.18.1",
         "debug": "^4.3.4"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.8.0.tgz",
-      "integrity": "sha512-xe0HNBVwCph7rak+ZHcFD6A+q50SMsFwcmfdjs9Kz4qDh5hWhaPhFjRs/SODEhroBI5Ruyvyz9LfwUJ624O40g==",
+      "version": "6.18.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.18.1.tgz",
+      "integrity": "sha512-BgdBwXPFmZzaZUuw6wKiHKIovms97a7eTImjkXCZE04TGHysG+0hDQPmygyvgtkoB/aOQwSM/nWv3LzrOIQOBw==",
+      "devOptional": true,
       "requires": {
-        "@typescript-eslint/types": "6.8.0",
-        "@typescript-eslint/visitor-keys": "6.8.0"
+        "@typescript-eslint/types": "6.18.1",
+        "@typescript-eslint/visitor-keys": "6.18.1"
       }
     },
     "@typescript-eslint/type-utils": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.8.0.tgz",
-      "integrity": "sha512-RYOJdlkTJIXW7GSldUIHqc/Hkto8E+fZN96dMIFhuTJcQwdRoGN2rEWA8U6oXbLo0qufH7NPElUb+MceHtz54g==",
+      "version": "6.18.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.18.1.tgz",
+      "integrity": "sha512-wyOSKhuzHeU/5pcRDP2G2Ndci+4g653V43gXTpt4nbyoIOAASkGDA9JIAgbQCdCkcr1MvpSYWzxTz0olCn8+/Q==",
+      "devOptional": true,
       "requires": {
-        "@typescript-eslint/typescript-estree": "6.8.0",
-        "@typescript-eslint/utils": "6.8.0",
+        "@typescript-eslint/typescript-estree": "6.18.1",
+        "@typescript-eslint/utils": "6.18.1",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.0.1"
       }
     },
     "@typescript-eslint/types": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.8.0.tgz",
-      "integrity": "sha512-p5qOxSum7W3k+llc7owEStXlGmSl8FcGvhYt8Vjy7FqEnmkCVlM3P57XQEGj58oqaBWDQXbJDZxwUWMS/EAPNQ=="
+      "version": "6.18.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.18.1.tgz",
+      "integrity": "sha512-4TuMAe+tc5oA7wwfqMtB0Y5OrREPF1GeJBAjqwgZh1lEMH5PJQgWgHGfYufVB51LtjD+peZylmeyxUXPfENLCw==",
+      "devOptional": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.8.0.tgz",
-      "integrity": "sha512-ISgV0lQ8XgW+mvv5My/+iTUdRmGspducmQcDw5JxznasXNnZn3SKNrTRuMsEXv+V/O+Lw9AGcQCfVaOPCAk/Zg==",
+      "version": "6.18.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.18.1.tgz",
+      "integrity": "sha512-fv9B94UAhywPRhUeeV/v+3SBDvcPiLxRZJw/xZeeGgRLQZ6rLMG+8krrJUyIf6s1ecWTzlsbp0rlw7n9sjufHA==",
+      "devOptional": true,
       "requires": {
-        "@typescript-eslint/types": "6.8.0",
-        "@typescript-eslint/visitor-keys": "6.8.0",
+        "@typescript-eslint/types": "6.18.1",
+        "@typescript-eslint/visitor-keys": "6.18.1",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
+        "minimatch": "9.0.3",
         "semver": "^7.5.4",
         "ts-api-utils": "^1.0.1"
+      },
+      "dependencies": {
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "devOptional": true,
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "9.0.3",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+          "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+          "devOptional": true,
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        }
       }
     },
     "@typescript-eslint/utils": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.8.0.tgz",
-      "integrity": "sha512-dKs1itdE2qFG4jr0dlYLQVppqTE+Itt7GmIf/vX6CSvsW+3ov8PbWauVKyyfNngokhIO9sKZeRGCUo1+N7U98Q==",
+      "version": "6.18.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.18.1.tgz",
+      "integrity": "sha512-zZmTuVZvD1wpoceHvoQpOiewmWu3uP9FuTWo8vqpy2ffsmfCE8mklRPi+vmnIYAIk9t/4kOThri2QCDgor+OpQ==",
+      "devOptional": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.4.0",
         "@types/json-schema": "^7.0.12",
         "@types/semver": "^7.5.0",
-        "@typescript-eslint/scope-manager": "6.8.0",
-        "@typescript-eslint/types": "6.8.0",
-        "@typescript-eslint/typescript-estree": "6.8.0",
+        "@typescript-eslint/scope-manager": "6.18.1",
+        "@typescript-eslint/types": "6.18.1",
+        "@typescript-eslint/typescript-estree": "6.18.1",
         "semver": "^7.5.4"
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.8.0.tgz",
-      "integrity": "sha512-oqAnbA7c+pgOhW2OhGvxm0t1BULX5peQI/rLsNDpGM78EebV3C9IGbX5HNZabuZ6UQrYveCLjKo8Iy/lLlBkkg==",
+      "version": "6.18.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.18.1.tgz",
+      "integrity": "sha512-/kvt0C5lRqGoCfsbmm7/CwMqoSkY3zzHLIjdhHZQW3VFrnz7ATecOHR7nb7V+xn4286MBxfnQfQhAmCI0u+bJA==",
+      "devOptional": true,
       "requires": {
-        "@typescript-eslint/types": "6.8.0",
+        "@typescript-eslint/types": "6.18.1",
         "eslint-visitor-keys": "^3.4.1"
       }
+    },
+    "@ungap/structured-clone": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
+      "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ=="
     },
     "@yarnpkg/lockfile": {
       "version": "1.1.0",
@@ -12721,9 +12820,9 @@
       "dev": true
     },
     "acorn": {
-      "version": "8.10.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
-      "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw=="
+      "version": "8.11.3",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
+      "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg=="
     },
     "acorn-jsx": {
       "version": "5.3.2",
@@ -13986,17 +14085,18 @@
       "dev": true
     },
     "eslint": {
-      "version": "8.51.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.51.0.tgz",
-      "integrity": "sha512-2WuxRZBrlwnXi+/vFSJyjMqrNjtJqiasMzehF0shoLaW7DzS3/9Yvrmq5JiT66+pNjiX4UBnLDiKHcWAr/OInA==",
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.56.0.tgz",
+      "integrity": "sha512-Go19xM6T9puCOWntie1/P997aXxFsOi37JIHRWI514Hc6ZnaHGKY9xFhrU65RT6CcBEzZoGG1e6Nq+DT04ZtZQ==",
       "requires": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
-        "@eslint/eslintrc": "^2.1.2",
-        "@eslint/js": "8.51.0",
-        "@humanwhocodes/config-array": "^0.11.11",
+        "@eslint/eslintrc": "^2.1.4",
+        "@eslint/js": "8.56.0",
+        "@humanwhocodes/config-array": "^0.11.13",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
+        "@ungap/structured-clone": "^1.2.0",
         "ajv": "^6.12.4",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
@@ -15017,9 +15117,9 @@
       }
     },
     "globals": {
-      "version": "13.23.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.23.0.tgz",
-      "integrity": "sha512-XAmF0RjlrjY23MA51q3HltdlGxUpXPvg0GioKiD9X6HD28iMjo2dKC8Vqwm7lne4GNr78+RHTfliktR6ZH09wA==",
+      "version": "13.24.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
       "requires": {
         "type-fest": "^0.20.2"
       },
@@ -17531,9 +17631,9 @@
       "dev": true
     },
     "punycode": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
-      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA=="
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="
     },
     "q": {
       "version": "1.5.1",
@@ -18446,6 +18546,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.3.tgz",
       "integrity": "sha512-wNMeqtMz5NtwpT/UZGY5alT+VoKdSsOOP/kqHFcUW1P/VRhH2wJ48+DN2WwUliNbQ976ETwDL0Ifd2VVvgonvg==",
+      "devOptional": true,
       "requires": {}
     },
     "tsconfig-paths": {

--- a/packages/eslint-config-nimble-core/lib/index.js
+++ b/packages/eslint-config-nimble-core/lib/index.js
@@ -24,7 +24,6 @@ module.exports = {
   },
   extends: [
     './rules/base',
-    './rules/typescript',
     './rules/import',
     './rules/prettier', // prettiter must be the last one
   ].map(require.resolve),

--- a/packages/eslint-config-nimble-core/lib/index.js
+++ b/packages/eslint-config-nimble-core/lib/index.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview eslint config
- * @author Nimbl3
+ * @author Nimble
  */
 'use strict';
 

--- a/packages/eslint-config-nimble-core/package.json
+++ b/packages/eslint-config-nimble-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimblehq/eslint-config-nimble-core",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "description": "ESLint base configuration developed and maintained by Nimble",
   "keywords": [
     "eslint",
@@ -10,11 +10,8 @@
   "author": "Nimble",
   "main": "lib/index.js",
   "dependencies": {
-    "@typescript-eslint/eslint-plugin": "^6.8.0",
-    "@typescript-eslint/parser": "^6.8.0",
     "eslint": "^8.51.0",
     "eslint-config-prettier": "^9.0.0",
-    "eslint-import-resolver-typescript": "^3.6.1",
     "eslint-plugin-import": "^2.28.1",
     "eslint-plugin-prettier": "^5.0.1"
   },

--- a/packages/eslint-config-nimble-react/lib/rules/base.js
+++ b/packages/eslint-config-nimble-react/lib/rules/base.js
@@ -7,7 +7,10 @@ module.exports = {
     node: true,
     jest: true,
   },
-  extends: '@nimblehq/eslint-config-nimble-core',
+  extends: [
+    '@nimblehq/eslint-config-nimble-core',
+    '@nimblehq/eslint-config-nimble-typescript',
+  ],
   parserOptions: {
     ecmaVersion: 6,
     sourceType: 'module',

--- a/packages/eslint-config-nimble-react/package.json
+++ b/packages/eslint-config-nimble-react/package.json
@@ -22,8 +22,8 @@
     "lib"
   ],
   "dependencies": {
-    "@nimblehq/eslint-config-nimble-core": "^2.8.0",
-    "@nimblehq/eslint-config-nimble-typescript": "^1.0.0",
+    "@nimblehq/eslint-config-nimble-core": "2.8.0",
+    "@nimblehq/eslint-config-nimble-typescript": "1.0.0",
     "eslint": "^8.51.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-jsx-a11y": "^6.7.1",

--- a/packages/eslint-config-nimble-react/package.json
+++ b/packages/eslint-config-nimble-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimblehq/eslint-config-nimble-react",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "ESLint React configuration developed and maintained by Nimble",
   "keywords": [
     "eslint",

--- a/packages/eslint-config-nimble-react/package.json
+++ b/packages/eslint-config-nimble-react/package.json
@@ -22,7 +22,8 @@
     "lib"
   ],
   "dependencies": {
-    "@nimblehq/eslint-config-nimble-core": "^2.7.0",
+    "@nimblehq/eslint-config-nimble-core": "^2.8.0",
+    "@nimblehq/eslint-config-nimble-typescript": "^1.0.0",
     "eslint": "^8.51.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-jsx-a11y": "^6.7.1",

--- a/packages/eslint-config-nimble-testing/lib/rules/base.js
+++ b/packages/eslint-config-nimble-testing/lib/rules/base.js
@@ -1,5 +1,8 @@
 'use strict';
 
 module.exports = {
-  extends: '@nimblehq/eslint-config-nimble-core',
+  extends: [
+    '@nimblehq/eslint-config-nimble-core',
+    '@nimblehq/eslint-config-nimble-typescript',
+  ],
 };

--- a/packages/eslint-config-nimble-testing/package.json
+++ b/packages/eslint-config-nimble-testing/package.json
@@ -13,8 +13,8 @@
   "author": "Nimble",
   "main": "lib/index.js",
   "dependencies": {
-    "@nimblehq/eslint-config-nimble-core": "^2.8.0",
-    "@nimblehq/eslint-config-nimble-typescript": "^1.0.0",
+    "@nimblehq/eslint-config-nimble-core": "2.8.0",
+    "@nimblehq/eslint-config-nimble-typescript": "1.0.0",
     "eslint": "^8.51.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-import": "^2.28.1",

--- a/packages/eslint-config-nimble-testing/package.json
+++ b/packages/eslint-config-nimble-testing/package.json
@@ -13,7 +13,8 @@
   "author": "Nimble",
   "main": "lib/index.js",
   "dependencies": {
-    "@nimblehq/eslint-config-nimble-core": "^2.7.0",
+    "@nimblehq/eslint-config-nimble-core": "^2.8.0",
+    "@nimblehq/eslint-config-nimble-typescript": "^1.0.0",
     "eslint": "^8.51.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-import": "^2.28.1",

--- a/packages/eslint-config-nimble-testing/package.json
+++ b/packages/eslint-config-nimble-testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimblehq/eslint-config-nimble-testing",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "ESLint testing plugin extension configuration developed and maintained by Nimble",
   "keywords": [
     "eslint",

--- a/packages/eslint-config-nimble-typescript/.eslintrc.js
+++ b/packages/eslint-config-nimble-typescript/.eslintrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: ['./lib/index.js'],
+};

--- a/packages/eslint-config-nimble-typescript/LICENSE
+++ b/packages/eslint-config-nimble-typescript/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2021 and onwards Nimble.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/packages/eslint-config-nimble-typescript/README.md
+++ b/packages/eslint-config-nimble-typescript/README.md
@@ -1,6 +1,6 @@
 # `@nimblehq/eslint-config-nimble-typescript`
 
-This package provides ESLint typescript rules inheriting from @nimblehq/eslint-config-nimble-core.
+This package provides ESLint Typescript rules inheriting from @nimblehq/eslint-config-nimble-core.
 
 ## Installation
 

--- a/packages/eslint-config-nimble-typescript/README.md
+++ b/packages/eslint-config-nimble-typescript/README.md
@@ -1,11 +1,63 @@
 # `@nimblehq/eslint-config-nimble-typescript`
 
-> TODO: description
+This package provides ESLint typescript rules inheriting from @nimblehq/eslint-config-nimble-core.
+
+## Installation
+
+```bash
+  npm install --save-dev @nimblehq/eslint-config-nimble-typescript
+```
 
 ## Usage
 
-```
-const eslintConfigNimbleTypescript = require('@nimblehq/eslint-config-nimble-typescript');
+### Standalone
 
-// TODO: DEMONSTRATE API
+Add `@nimblehq/eslint-config-nimble-typescript` to the extends section of your `.eslintrc` configuration file.
+
+```js
+{
+  "extends": [
+      "@nimblehq/eslint-config-nimble-typescript"
+  ],
+  "rules": {
+    // Additional, per-project rules...
+  }
+}
 ```
+
+### With a framework
+
+Similar to the process above, but usually it requires adding the extra rules for the JS framework:
+
+```js
+{
+  "extends": [
+      "@nimblehq/eslint-config-nimble-testing",
+      "plugin:react/recommended",
+      "plugin:vue/recommended"
+  ],
+  "rules": {
+    // Additional, per-project rules...
+  }
+}
+```
+
+This would require defining the required dependencies in the project itself.
+
+## License
+
+This project is Copyright (c) 2021 and onwards Nimble. It is free software and may be redistributed under the terms specified in the [LICENSE] file.
+
+[LICENSE]: /LICENSE
+
+## About
+
+![Nimble](https://assets.nimblehq.co/logo/dark/logo-dark-text-160.png)
+
+This project is maintained and funded by [Nimble](https://nimblehq.co).
+
+We love open source and do our part in sharing our work with the community!
+See [our other projects][community] or [hire our team][hire] to help build your product.
+
+[community]: https://github.com/nimblehq
+[hire]: https://nimblehq.co/

--- a/packages/eslint-config-nimble-typescript/README.md
+++ b/packages/eslint-config-nimble-typescript/README.md
@@ -1,0 +1,11 @@
+# `@nimblehq/eslint-config-nimble-typescript`
+
+> TODO: description
+
+## Usage
+
+```
+const eslintConfigNimbleTypescript = require('@nimblehq/eslint-config-nimble-typescript');
+
+// TODO: DEMONSTRATE API
+```

--- a/packages/eslint-config-nimble-typescript/README.md
+++ b/packages/eslint-config-nimble-typescript/README.md
@@ -32,7 +32,7 @@ Similar to the process above, but usually it requires adding the extra rules for
 ```js
 {
   "extends": [
-      "@nimblehq/eslint-config-nimble-testing",
+      "@nimblehq/eslint-config-nimble-typescript",
       "plugin:react/recommended",
       "plugin:vue/recommended"
   ],

--- a/packages/eslint-config-nimble-typescript/lib/index.js
+++ b/packages/eslint-config-nimble-typescript/lib/index.js
@@ -1,5 +1,5 @@
 /**
- * @fileoverview eslint testing config
+ * @fileoverview eslint typescript config
  * @author Nimble
  */
 'use strict';

--- a/packages/eslint-config-nimble-typescript/lib/index.js
+++ b/packages/eslint-config-nimble-typescript/lib/index.js
@@ -1,0 +1,10 @@
+/**
+ * @fileoverview eslint testing config
+ * @author Nimble
+ */
+'use strict';
+
+module.exports = {
+  extends: ['./rules/base', './rules/typescript'].map(require.resolve),
+  rules: {},
+};

--- a/packages/eslint-config-nimble-typescript/lib/rules/base.js
+++ b/packages/eslint-config-nimble-typescript/lib/rules/base.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = {
+  extends: '@nimblehq/eslint-config-nimble-core',
+};

--- a/packages/eslint-config-nimble-typescript/lib/rules/typescript.js
+++ b/packages/eslint-config-nimble-typescript/lib/rules/typescript.js
@@ -16,9 +16,4 @@ module.exports = {
     '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
     '@typescript-eslint/no-use-before-define': ['error'],
   },
-  env: {
-    browser: true,
-    commonjs: true,
-    es2021: true,
-  },
 };

--- a/packages/eslint-config-nimble-typescript/lib/rules/typescript.js
+++ b/packages/eslint-config-nimble-typescript/lib/rules/typescript.js
@@ -16,4 +16,9 @@ module.exports = {
     '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
     '@typescript-eslint/no-use-before-define': ['error'],
   },
+  env: {
+    browser: true,
+    commonjs: true,
+    es2021: true,
+  },
 };

--- a/packages/eslint-config-nimble-typescript/package.json
+++ b/packages/eslint-config-nimble-typescript/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@nimblehq/eslint-config-nimble-typescript",
+  "version": "1.0.0",
+  "description": "ESLint config for TypeScript projects by Nimble",
+  "keywords": [
+    "eslint",
+    "eslintconfig",
+    "eslint-config",
+    "typescript",
+    "nimble",
+    "nimblehq"
+  ],
+  "author": "Nimble",
+  "main": "lib/index.js",
+  "dependencies": {
+    "@nimblehq/eslint-config-nimble-core": "^2.8.0",
+    "eslint-import-resolver-typescript": "^3.6.1"
+  },
+  "scripts": {
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix"
+  },
+  "license": "MIT",
+  "directories": {
+    "lib": "lib"
+  },
+  "engines": {
+    "node": "^14.18.2 || >=18"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/nimblehq/eslint-config-nimble.git"
+  },
+  "bugs": {
+    "url": "https://github.com/nimblehq/eslint-config-nimble/issues"
+  },
+  "homepage": "https://github.com/nimblehq/eslint-config-nimble",
+  "files": [
+    "lib"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "devDependencies": {
+    "@typescript-eslint/eslint-plugin": "^6.18.1",
+    "@typescript-eslint/parser": "^6.18.1",
+    "eslint": "^8.56.0"
+  }
+}

--- a/packages/eslint-config-nimble-typescript/package.json
+++ b/packages/eslint-config-nimble-typescript/package.json
@@ -13,7 +13,7 @@
   "author": "Nimble",
   "main": "lib/index.js",
   "dependencies": {
-    "@nimblehq/eslint-config-nimble-core": "^2.8.0",
+    "@nimblehq/eslint-config-nimble-core": "2.8.0",
     "eslint-import-resolver-typescript": "^3.6.1"
   },
   "scripts": {


### PR DESCRIPTION
- Close #56

## What happened 👀

As some projects don't have built-in `typescript` such as Rails, we need to separate `typescript` rules from the `core` package. Later, for those who need the rules for typescript, we need to extend it explicitly.

- [x] Separate `typescript` to a dedicated package named `eslint-config-nimble-typescript`
- [x] Update the README
- [x] Release the new package 

## Insight 📝

`n/a`

## Proof Of Work 📹


| Ran it successfully on local                                                                                                              |
|-------------------------------------------------------------------------------------------------------------------------------------------|
| <img width="673" alt="image" src="https://github.com/nimblehq/eslint-config-nimble/assets/63148598/6d9ea797-bb1d-4415-8cd9-6f53ebf9e2f1"> |
