### PR TITLE
[#56] Remove parser and settings option from `core` package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10313,7 +10313,7 @@
     },
     "packages/eslint-config-nimble-react": {
       "name": "@nimblehq/eslint-config-nimble-react",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "@nimblehq/eslint-config-nimble-core": "2.8.0",
@@ -10332,7 +10332,7 @@
     },
     "packages/eslint-config-nimble-testing": {
       "name": "@nimblehq/eslint-config-nimble-testing",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "@nimblehq/eslint-config-nimble-core": "2.8.0",

--- a/packages/eslint-config-nimble-core/lib/rules/import.js
+++ b/packages/eslint-config-nimble-core/lib/rules/import.js
@@ -3,7 +3,6 @@
 module.exports = {
   plugins: ['import'],
   extends: ['plugin:import/recommended'],
-  parser: '@typescript-eslint/parser',
   rules: {
     'import/order': [
       'error',
@@ -40,14 +39,5 @@ module.exports = {
         spec: 'always',
       },
     ],
-  },
-  settings: {
-    'import/resolver': {
-      typescript: {},
-      node: {
-        extensions: ['.js', '.jsx', '.ts', '.tsx'],
-        moduleDirectory: ['node_modules', 'src/'],
-      },
-    },
   },
 };

--- a/packages/eslint-config-nimble-typescript/lib/rules/typescript.js
+++ b/packages/eslint-config-nimble-typescript/lib/rules/typescript.js
@@ -16,4 +16,13 @@ module.exports = {
     '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
     '@typescript-eslint/no-use-before-define': ['error'],
   },
+  settings: {
+    'import/resolver': {
+      typescript: {},
+      node: {
+        extensions: ['.js', '.jsx', '.ts', '.tsx'],
+        moduleDirectory: ['node_modules', 'src/'],
+      },
+    },
+  },
 };


### PR DESCRIPTION
- Close #56

## What happened 👀

As we removed `typescript` from the core package, we also need to move `parser` and `settings` that belong to `typescript` out of it.

## Insight 📝

After releasing the new package, I installed the latest one and tried running it locally. 

Firstly, it raised this error.

```
Error: Failed to load parser '@typescript-eslint/parser' declared in '.eslintrc » @nimblehq/eslint-config-nimble-core » 
/test_web/node_modules/@nimblehq/eslint-config-nimble-core/lib/rules/import.js': 
Cannot find module '@typescript-eslint/parser'
```

Then, I tried removing the `parser` option, this time it's better, I ran through the code base but then another one popped up:

![image](https://github.com/nimblehq/eslint-config-nimble/assets/63148598/6cb3e9b0-e355-4711-bbc5-566d4008fc3d)

-> It's because of the `typescript` option from the `settings` option.

## Proof Of Work 📹

| Seems like it raises the expect result                                                                          |
|-----------------------------------------------------------------------------------------------------------------|
| ![image](https://github.com/nimblehq/eslint-config-nimble/assets/63148598/cfaf5809-d364-452a-b451-03cdecac6eda) |